### PR TITLE
Fixed potential ModuleNotFound bug

### DIFF
--- a/Back_End/__init__.py
+++ b/Back_End/__init__.py
@@ -1,3 +1,9 @@
+import sys
+import os
+from pathlib import Path
+current_path = Path(os.getcwd())
+sys.path.append(str(current_path.parent))
+
 from colorama import Fore, init
 import logging
 
@@ -50,12 +56,21 @@ def create_app():
 
     # Registering the blueprints
     # Landing page
-    from Back_End import landing_page, patients, doctors, chemists, login
-    app.register_blueprint(landing_page.bp)
-    app.register_blueprint(patients.bp)
-    app.register_blueprint(doctors.bp)
-    app.register_blueprint(chemists.bp)
-    app.register_blueprint(login.bp)
+    try:
+        from Back_End import landing_page, patients, doctors, chemists, login
+    except ModuleNotFoundError as error:
+        print("ModuleNotFoundError:", error)
+        print("Are you sure you are running this file from `RICA` or `RICA/Back_End` directory?")
+        print("Try running with `python -m __init__.py` or `python -m app.py` in Back_End.")
+        print("Or if you are running from parent directory, try `python -m Back_End.app` or `python -m "
+              "Back_End.__init__.py`")
+        quit()
+    else:
+        app.register_blueprint(landing_page.bp)
+        app.register_blueprint(patients.bp)
+        app.register_blueprint(doctors.bp)
+        app.register_blueprint(chemists.bp)
+        app.register_blueprint(login.bp)
 
     return app
 

--- a/Back_End/app.py
+++ b/Back_End/app.py
@@ -1,6 +1,17 @@
-from Back_End import create_app
+import sys
+import os
+from pathlib import Path
+current_path = Path(os.getcwd())
+sys.path.append(str(current_path.parent))
+
+try:
+    from Back_End import create_app
+except ModuleNotFoundError as e:
+    print("ModuleNotFoundError:", e)
+    print("Are you sure you are running this file from `RICA/Back_End` directory?")
+    print("Try running `flask run` in Back_End.")
+    quit()
 
 if __name__ == '__main__':
     app = create_app()
     app.run(debug=True)
-

--- a/Back_End/patients.py
+++ b/Back_End/patients.py
@@ -1,5 +1,5 @@
 import datetime
-from book_appointment.send_appointment import add_appointment
+from .book_appointment.send_appointment import add_appointment
 from flask import request, redirect
 
 from Back_End.common_modules import *


### PR DESCRIPTION
fixed the bug that @shreyanshsharma88 reported that he got `ModuleNotFoundError` when running from the wrong directory
issue was replicated when running via terminal from my side too.
Pycharm added the project's root folder's path to sys.path / PYTHONPATH, hence i did the same by hardocding it manually.

Also added exception handling that if ImportError occurs, then the user is asked whether they've run the file from the correct directory or not

References:
https://stackoverflow.com/questions/16480898/receiving-import-error-no-module-named-but-has-init-py
https://stackoverflow.com/questions/6323860/sibling-package-imports/23542795#23542795
https://stackoverflow.com/questions/6323860/sibling-package-imports